### PR TITLE
Refactor scatterplot

### DIFF
--- a/smh/gui/base.py
+++ b/smh/gui/base.py
@@ -262,14 +262,14 @@ class SMHSpecDisplay(mpl.MPLWidget):
         self.selected_model = model
         self._set_xlimits(self._get_current_xlimits())
         self.reset_zoom_limits()
-    def _get_current_xlimits(self):
+    def _get_current_xlimits(self, scale=1.02):
         if self.session is None: return None
         if self.selected_model is None: return None
         transitions = self.selected_model.transitions
         window = self.selected_model.metadata["window"]
         limits = [
-            transitions["wavelength"][0] - window,
-            transitions["wavelength"][-1]+ window,
+            transitions["wavelength"][0] - window*scale,
+            transitions["wavelength"][-1]+ window*scale,
         ]
         return limits
     def _set_xlimits(self, limits):

--- a/smh/gui/chemical_abundances.py
+++ b/smh/gui/chemical_abundances.py
@@ -71,6 +71,7 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         self.parent_layout.addWidget(self.figure)
         self.figure.add_callback_after_fit(self.refresh_current_model)
         self.figure.add_callback_after_fit(self.summarize_current_table)
+        self.figure.mpl_connect("key_press_event", self.key_press_selectcheck)
         ## Stuff for extra synthesis
         self.extra_spec_1 = self.ax_spectrum.plot([np.nan],[np.nan], ls='-', color='#cea2fd', lw=1.5, zorder=9999)[0]
         self.extra_spec_2 = self.ax_spectrum.plot([np.nan],[np.nan], ls='-', color='#ffb07c', lw=1.5, zorder=9999)[0]
@@ -1494,6 +1495,24 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         if spectral_model is None: return None
         self.measurement_view.update_row(proxy_index.row())
         self.update_fitting_options()
+
+    def key_press_selectcheck(self, event):
+        print("'"+event.key+"'")
+        if "'"+event.key+"'" == "' '":
+            model, proxy_index, index = self._get_selected_model(True)
+            model.is_acceptable = np.logical_not(model.is_acceptable)
+            self.measurement_view.update_row(proxy_index.row())
+            self.update_spectrum_figure(redraw=True)
+            return None
+        if event.key not in ["up","down","j", "J", "k", "K"]: return None
+        try:
+            proxy_index_row = self.measurement_view.selectionModel().selectedRows()[-1].row()
+        except IndexError:
+            return None
+        if event.key in ["up", "j", "J"]: proxy_index_row -= 1
+        if event.key in ["down", "k", "K"]: proxy_index_row += 1
+        self.measurement_view.selectRow(proxy_index_row)
+        return None
 
 class SynthesisAbundanceTableView(QtGui.QTableView):
     """

--- a/smh/gui/chemical_abundances.py
+++ b/smh/gui/chemical_abundances.py
@@ -1497,12 +1497,16 @@ class ChemicalAbundancesTab(QtGui.QWidget):
         self.update_fitting_options()
 
     def key_press_selectcheck(self, event):
-        print("'"+event.key+"'")
         if "'"+event.key+"'" == "' '":
             model, proxy_index, index = self._get_selected_model(True)
             model.is_acceptable = np.logical_not(model.is_acceptable)
             self.measurement_view.update_row(proxy_index.row())
             self.update_spectrum_figure(redraw=True)
+            return None
+        if event.key in ["f", "F"]:
+            model, proxy_index, index = self._get_selected_model(True)
+            model.user_flag = np.logical_not(model.user_flag)
+            self.measurement_view.update_row(proxy_index.row())
             return None
         if event.key not in ["up","down","j", "J", "k", "K"]: return None
         try:

--- a/smh/session.py
+++ b/smh/session.py
@@ -1102,7 +1102,7 @@ class Session(BaseSession):
         sigma_s = spectral_model.propagate_stellar_parameter_error()
                   stored in spectral_model.metadata["systematic_abundance_error"]
     """
-    def compute_all_abundance_uncertainties(self):
+    def compute_all_abundance_uncertainties(self, print_memory_usage=False):
         """
         Call model.find_error() and model.propagate_stellar_parameter_error() for every
         acceptable spectral model that is not an upper limit.
@@ -1143,6 +1143,14 @@ class Session(BaseSession):
             data[i,5] = staterr
             data[i,6] = syserr
             data[i,7] = np.sqrt(staterr**2 + syserr**2)
+
+            if print_memory_usage:
+                import psutil
+                import resource
+                process = psutil.Process(os.getpid())
+                print(species, wavelength, process.memory_info().rss)  # in bytes 
+                print("    ",resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)  # in bytes 
+                
         self.metadata["all_line_data"] = data
         logger.info("Finished abundance uncertainty loop in {:.1f}s".format(time.time()-start))
         return data

--- a/smh/utils.py
+++ b/smh/utils.py
@@ -668,7 +668,8 @@ def process_session_uncertainties_lines(session, rhomat, minerr=0.001):
             syserr_sq = e_all.T.dot(rhomat.dot(e_all))
             syserr = np.sqrt(syserr_sq)
             fwhm = model.fwhm
-        except:
+        except Exception as e:
+            print(e)
             logeps, staterr, e_Teff, e_logg, e_vt, e_MH, syserr = np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan
 
         if isinstance(model, ProfileFittingModel):


### PR DESCRIPTION
Two things to improve usability of chemical abundances tab:

- fixed automatically adding 2% to the x limits when plotting an equivalent width line, to make it easier to mask edges
- added keyboard shortcuts in the chemical abundances tab. When you are clicked into the spectrum plot (e.g. after a mask), you can now:
  - use the spacebar to check/uncheck lines [the spectrum fit should change color]
  - use the j/k or up/down keys to scroll back/forwards in the measurement table

I think there might be some overlap with other things that you have implemented into smhr-rpa, you can decide how you want to merge these things if you want.

I couldn't figure out how to get the qt table to recognize the spacebar and j/k keys but I'm sure it's possible somehow...